### PR TITLE
Disables image prePuller for local jupyterhub profiles

### DIFF
--- a/jupyterhub/garden.yaml
+++ b/jupyterhub/garden.yaml
@@ -157,6 +157,11 @@ spec:
           image_pull_policy: IfNotPresent
           node_selector:
             teehr-hub/nodegroup-name: nb-r5-xlarge
+    prePuller:
+      hook:
+        enabled: false
+      continuous:
+        enabled: false
 
     scheduling:
       userScheduler:


### PR DESCRIPTION
Currently jupyterhub tries to pull images during deployment. _External images_* that are not already present in the kind image registry are causing the deployment to fail.

This updates the jupyterhub configuration to not attempt pulling images during deployment but only when they are needed when a user selects that image to start the server. If the image is not present at this time, server startup fails.



\* i.e. images that are not built during the garden deployment