### PR TITLE
hefs-fews jupyterhub config updates

### DIFF
--- a/jupyterhub/garden.yaml
+++ b/jupyterhub/garden.yaml
@@ -642,7 +642,17 @@ spec:
               hefs-v0-3-0:
                 display_name: HEFS-FEWS v0.3.x - XL (4 cores, 16 GB memory)
                 kubespawner_override:
-                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:v0.3.0"
+                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:v0.3"
+                  mem_limit: 32G
+                  mem_guarantee: 19G
+                  cpu_limit: 4
+                  cpu_guarantee: 3
+                  node_selector:
+                    teehr-hub/nodegroup-name: nb-r5-xlarge-firo
+              hefs-latest:
+                display_name: HEFS-FEWS Bleeding Edge - XL (4 cores, 16 GB memory)
+                kubespawner_override:
+                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:dev"
                   mem_limit: 32G
                   mem_guarantee: 19G
                   cpu_limit: 4

--- a/jupyterhub/garden.yaml
+++ b/jupyterhub/garden.yaml
@@ -568,9 +568,30 @@ spec:
           image:
             display_name: Image
             choices:
+              hefs-v0-3-0:
+                display_name: HEFS-FEWS v0.3.x - XL (4 cores, 16 GB memory)
+                default: true
+                kubespawner_override:
+                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:v0.3"
+                  mem_limit: 32G
+                  mem_guarantee: 19G
+                  cpu_limit: 4
+                  cpu_guarantee: 3
+                  node_selector:
+                    teehr-hub/nodegroup-name: nb-r5-xlarge-firo
+              hefs-latest:
+                display_name: HEFS-FEWS Bleeding Edge - XL (4 cores, 16 GB memory)
+                kubespawner_override:
+                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:dev"
+                  image_pull_policy: IfNotPresent
+                  mem_limit: 32G
+                  mem_guarantee: 19G
+                  cpu_limit: 4
+                  cpu_guarantee: 3
+                  node_selector:
+                    teehr-hub/nodegroup-name: nb-r5-xlarge-firo
               current-tag-xlarge:
                 display_name: Version ${var.stableTeehrVersion} - XL (4 cores, 16 GB memory) 
-                default: true
                 kubespawner_override:
                   image: ${actions.build.teehr-jupyter-driver-image-stable.outputs.deploymentImageId}
                   mem_limit: 32G
@@ -629,36 +650,6 @@ spec:
                   cpu_guarantee: 12
                   node_selector:
                     teehr-hub/nodegroup-name: nb-r5-4xlarge-firo
-              hefs-v0-1-0:
-                display_name: HEFS-FEWS v0.1.x - XL (4 cores, 16 GB memory)
-                kubespawner_override:
-                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:v0.1.0"
-                  mem_limit: 32G
-                  mem_guarantee: 19G
-                  cpu_limit: 4
-                  cpu_guarantee: 3
-                  node_selector:
-                    teehr-hub/nodegroup-name: nb-r5-xlarge-firo
-              hefs-v0-3-0:
-                display_name: HEFS-FEWS v0.3.x - XL (4 cores, 16 GB memory)
-                kubespawner_override:
-                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:v0.3"
-                  mem_limit: 32G
-                  mem_guarantee: 19G
-                  cpu_limit: 4
-                  cpu_guarantee: 3
-                  node_selector:
-                    teehr-hub/nodegroup-name: nb-r5-xlarge-firo
-              hefs-latest:
-                display_name: HEFS-FEWS Bleeding Edge - XL (4 cores, 16 GB memory)
-                kubespawner_override:
-                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:dev"
-                  mem_limit: 32G
-                  mem_guarantee: 19G
-                  cpu_limit: 4
-                  cpu_guarantee: 3
-                  node_selector:
-                    teehr-hub/nodegroup-name: nb-r5-xlarge-firo
         kubespawner_override:
           environment:
             TEEHR_PROJECT_ID: "FIRO"
@@ -732,26 +723,6 @@ spec:
                   cpu_guarantee: 12
                   node_selector:
                     teehr-hub/nodegroup-name: nb-r5-4xlarge-fff
-              hefs-v0-1-0:
-                display_name: XL (r5-xlarge, 4 cores, 16 GB memory) (HEFS-FEWS v0.1.x)
-                kubespawner_override:
-                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:v0.1.0"
-                  mem_limit: 32G
-                  mem_guarantee: 19G
-                  cpu_limit: 4
-                  cpu_guarantee: 3
-                  node_selector:
-                    teehr-hub/nodegroup-name: nb-r5-xlarge-fff
-              hefs-v0-3-0:
-                display_name: XL (r5-xlarge, 4 cores, 16 GB memory) (HEFS-FEWS v0.3.x)
-                kubespawner_override:
-                  image: "935462133478.dkr.ecr.us-east-2.amazonaws.com/hefs-fews-hub:v0.3.0"
-                  mem_limit: 32G
-                  mem_guarantee: 19G
-                  cpu_limit: 4
-                  cpu_guarantee: 3
-                  node_selector:
-                    teehr-hub/nodegroup-name: nb-r5-xlarge-fff
         kubespawner_override:
           environment:
             TEEHR_PROJECT_ID: "FFF"


### PR DESCRIPTION
Updates the minor version reference to actually point to the latest minor version (not patch) and adds a Bleeding Edge choice that points to a `dev` tag.

BTW, I'd also like to understand the logic for how the server options are set up now :)
