### PR TITLE
Adds notebook to delete nrds lstm short and medium range

### DIFF
--- a/warehouse/02_loading/deletes/01_delete_nrds_lstm.ipynb
+++ b/warehouse/02_loading/deletes/01_delete_nrds_lstm.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac511c9a-29a2-4353-a914-15922714cc91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import teehr\n",
+    "from teehr.evaluation.spark_session_utils import create_spark_session"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ce87132-6d8a-4ef8-9d8c-adba09bc66b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "spark = create_spark_session(\n",
+    "    aws_profile=\"default\"\n",
+    ")\n",
+    "\n",
+    "ev = teehr.RemoteReadWriteEvaluation(spark=spark)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffe5df38-0209-4621-aa5b-3bf01dc6c591",
+   "metadata": {},
+   "source": [
+    "#### Delete NRDS LSTM timeseries (short and medium range) and configuration names:\n",
+    "- nrds_v22_lstm_short_range\n",
+    "- nrds_v22_lstm_medium_range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b636a60a-6ec0-45fb-b65e-824739625212",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "sdf = ev._write.delete_from(\n",
+    "    table_name=\"secondary_timeseries\",\n",
+    "    filters=[\"configuration_name = 'nrds_v22_lstm_medium_range'\"],\n",
+    "    dry_run=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7ddd6e2-9428-41ac-bc7f-fcd13cc0a008",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sdf.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da5bbdb8-dddc-4ed0-af49-ed7e24f4ac6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d253d408-c557-4319-ae2a-266edc765dfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "sdf = ev._write.delete_from(\n",
+    "    table_name=\"configurations\",\n",
+    "    filters=[\"name = 'nrds_v22_lstm_medium_range'\"],\n",
+    "    dry_run=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8b339fa-237f-4a1c-9ee7-6de3ff9d1b54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c12cd8ef-aac6-4f9d-8698-4986c453f9aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ev.list_tables()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a70a8d75-9b83-4544-a1d1-7abecfe0fbcc",
+   "metadata": {},
+   "source": [
+    "Let's check unique secondary prefixes in the crosswalk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a86a367-aa10-47fe-8261-f2f9a8d9bc45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sdf = ev.spark.sql(\"\"\"\n",
+    "    SELECT DISTINCT\n",
+    "        SPLIT(secondary_location_id, '-')[0] AS prefix\n",
+    "    FROM iceberg.teehr.location_crosswalks\n",
+    "    WHERE secondary_location_id LIKE '%-%'\n",
+    "\"\"\")\n",
+    "sdf.show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64895e5b-37d7-4520-9296-aaa65480dc09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ev.configurations.to_sdf().show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a678eb0-b9e1-4793-befe-6b9c702ba4cf",
+   "metadata": {},
+   "source": [
+    "Check unique configuration names in the secondary table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4295032-371c-491d-a7bc-1f9c0b14359c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sdf = ev.spark.sql(\"\"\"\n",
+    "    SELECT DISTINCT configuration_name\n",
+    "    FROM iceberg.teehr.secondary_timeseries\n",
+    "\"\"\")\n",
+    "sdf.show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3c4c9d0-e962-414a-84ac-9f43a773c19f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a notebook in `warehouse/02_loading/deletes` to remove the `nrds_v22_lstm_medium_range` and `nrds_v22_lstm_short_range` timeseries and configuration names from the warehouse.

This was run and data deleted ✅ 