### PR TITLE
289 setup local services to require reduced resources

### DIFF
--- a/api/manifests/deployment.yaml.tpl
+++ b/api/manifests/deployment.yaml.tpl
@@ -153,7 +153,7 @@ spec:
         resources:
           requests:
             cpu: 1
-            memory: 4Gi
+            memory: "${environment.name == 'local' ? '1Gi' : '4Gi'}"
           limits:
             cpu: 2
             memory: 8Gi

--- a/keycloak/manifests/keycloak.yaml.tpl
+++ b/keycloak/manifests/keycloak.yaml.tpl
@@ -32,7 +32,7 @@ spec:
   resources:
     requests:
       cpu: 250m
-      memory: 1Gi
+      memory: "${environment.name == 'local' ? '512Mi' : '1Gi'}"
     limits:
       cpu: "1"
       memory: 2Gi

--- a/monitoring/garden.yaml
+++ b/monitoring/garden.yaml
@@ -68,7 +68,7 @@ spec:
         resources:
           requests:
             cpu: 200m
-            memory: 1Gi
+            memory: "${environment.name == 'local' ? '512Mi' : '1Gi'}"
           limits:
             cpu: 1
             memory: 2Gi

--- a/panel-dashboards/manifests/panel-app.yaml.tpl
+++ b/panel-dashboards/manifests/panel-app.yaml.tpl
@@ -33,7 +33,7 @@ spec:
         resources:
           requests:
             cpu: 200m
-            memory: 512Mi
+            memory: "${environment.name == 'local' ? '256Mi' : '512Mi'}"
           limits:
             cpu: 1
             memory: 2Gi

--- a/prefect-pg/garden.yaml
+++ b/prefect-pg/garden.yaml
@@ -8,5 +8,5 @@ environments:
   - local
   - remote
 spec:
-  manifestFiles:
-  - ./manifests/prefect-pg.yaml
+  manifestTemplates:
+  - ./manifests/prefect-pg.yaml.tpl

--- a/prefect-pg/manifests/prefect-pg.yaml.tpl
+++ b/prefect-pg/manifests/prefect-pg.yaml.tpl
@@ -77,7 +77,7 @@ spec:
           resources:
             requests:
               cpu: "2"
-              memory: 4Gi
+              memory: "${environment.name == 'local' ? '1Gi' : '4Gi'}"
             limits:
               cpu: "4"
               memory: 8Gi

--- a/prefect-server/garden.yaml
+++ b/prefect-server/garden.yaml
@@ -28,7 +28,7 @@ spec:
       resources:
         requests:
           cpu: "1"
-          memory: 2Gi
+          memory: "${environment.name == 'local' ? '1Gi' : '2Gi'}"
         limits:
           cpu: "2"
           memory: 4Gi

--- a/prefect-workflows/manifests/prefect-deployer-job.yaml
+++ b/prefect-workflows/manifests/prefect-deployer-job.yaml
@@ -61,7 +61,7 @@ spec:
         resources:
           requests:
             cpu: 500m
-            memory: 512Mi
+            memory: "${environment.name == 'local' ? '256Mi' : '512Mi'}"
           limits:
             cpu: 1000m
             memory: 1Gi

--- a/trino/garden.yaml
+++ b/trino/garden.yaml
@@ -84,7 +84,7 @@ spec:
       resources:
         requests:
           cpu: 1
-          memory: 4Gi
+          memory: "${environment.name == 'local' ? '1Gi' : '4Gi'}"
         limits:
           cpu: 2
           memory: 8Gi
@@ -95,7 +95,7 @@ spec:
       resources:
         requests:
           cpu: 1
-          memory: 4Gi
+          memory: "${environment.name == 'local' ? '1Gi' : '4Gi'}"
         limits:
           cpu: 2
           memory: 8Gi

--- a/trino/garden.yaml
+++ b/trino/garden.yaml
@@ -76,7 +76,7 @@ spec:
   
   values:
     server:
-      workers: 2
+      workers: "${environment.name == 'local' ? 1 : 2}"
 
     coordinator:
       # nodeSelector:


### PR DESCRIPTION
Reduces memory request floor for teehr-hub services by the following in the `local` env:
- Reduce requests >1Gi to 1Gi
- Reduce requests ==1Gi to 512Mi
- Reduce requests ==512Mi to 256Mi

Also reduces trino workers in `local` to 1.

Testing: Ran through full "Load Test Data to Warehouse" process and verified in dashboard (in WSL w/ 24GB of allocated memory).

---

Current branch does not reduce memory limits as doing so would potentially cap the resources a more powerful machine can utilize for local dev deployment.  However, testing indicated that a WSL instance with ~8GB of memory could not run teehr-hub in a stable manner.

Reducing memory limits did create more stability for an ~8GB host, but would eventually crash under load -- it seems unlikely that 8GB of memory is sufficient to adequately deploy the infrastructure for development without significant tweaking and troubleshooting of resource allocation.  The resulting environment would likely need to be separate from the general local instance (`local-lite`?) to avoid limiting machines with more resources.