### PR TITLE
feat: change apt sources to HTTPS

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,6 +4,9 @@ FROM python:3.12-slim
 # Set working directory
 WORKDIR /app
 
+# Use HTTPS apt mirrors so builds work when plain HTTP egress is blocked.
+RUN sed -i 's|http://deb.debian.org/debian|https://deb.debian.org/debian|g; s|http://deb.debian.org/debian-security|https://deb.debian.org/debian-security|g' /etc/apt/sources.list.d/debian.sources
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     gcc \

--- a/jupyterhub/docker/Dockerfile.jupyter-driver
+++ b/jupyterhub/docker/Dockerfile.jupyter-driver
@@ -7,6 +7,15 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH=${NB_PYTHON_PREFIX}/bin:$PATH
 
+# Use HTTPS apt mirrors so builds work when plain HTTP egress is blocked.
+RUN set -eux; \
+    if [ -f /etc/apt/sources.list ]; then \
+      sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g; s|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list; \
+    fi; \
+    if [ -d /etc/apt/sources.list.d ]; then \
+      find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g; s|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' {} +; \
+    fi
+
 # Needed for apt-key to work -- Is this part needed?
 RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq gnupg2 > /dev/null && \

--- a/prefect-workflows/Dockerfile.prefect-teehr
+++ b/prefect-workflows/Dockerfile.prefect-teehr
@@ -5,6 +5,9 @@ ARG TEEHR_VERSION
 # Use Docker BuildKit's automatic architecture detection
 ARG TARGETARCH
 
+# Use HTTPS apt mirrors so builds work when plain HTTP egress is blocked.
+RUN sed -i 's|http://deb.debian.org/debian|https://deb.debian.org/debian|g; s|http://deb.debian.org/debian-security|https://deb.debian.org/debian-security|g' /etc/apt/sources.list.d/debian.sources
+
 # Install Java 21 and other dependencies (matching Jupyter driver)
 # We should switch to openjdk-17-jdk
 RUN apt-get update && apt-get install -y \

--- a/spark/docker/Dockerfile.spark-executor
+++ b/spark/docker/Dockerfile.spark-executor
@@ -5,6 +5,9 @@ USER 0
 
 ARG TEEHR_VERSION
 
+# Use HTTPS apt mirrors so builds work when plain HTTP egress is blocked.
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+
 # Add deadsnakes PPA and install Python 3.12
 RUN apt-get update && apt-get install -y \
     software-properties-common \


### PR DESCRIPTION
Some cloud environments hosting TEEHR deployments do not support HTTP egress. Use HTTPS by default.