### PR TITLE
feat: import deployment ingress manifests

### DIFF
--- a/ingress/garden.yaml
+++ b/ingress/garden.yaml
@@ -7,3 +7,13 @@ spec:
 environments:
   - local
   - remote
+---
+kind: Deploy
+type: kubernetes
+name: dashboards-ingress
+spec:
+  manifestTemplates:
+    - manifests/dashboards.yaml.tpl
+environments:
+  - local
+  - remote

--- a/ingress/garden.yaml
+++ b/ingress/garden.yaml
@@ -1,0 +1,9 @@
+kind: Deploy
+type: kubernetes
+name: panel-ingress
+spec:
+  manifestTemplates:
+    - manifests/panel.yaml.tpl
+environments:
+  - local
+  - remote

--- a/ingress/manifests/dashboards.yaml.tpl
+++ b/ingress/manifests/dashboards.yaml.tpl
@@ -1,0 +1,20 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: dashboards-httpproxy
+  namespace: ${environment.namespace}
+spec:
+  virtualhost:
+    fqdn: dashboards.${var.hostname}
+    tls:
+      secretName: dashboards.${var.hostname}-tls
+  routes:
+  - conditions:
+    - prefix: /
+    services:
+    - name: teehr-frontend
+      port: 8080
+    enableWebsockets: true
+    timeoutPolicy:
+      response: 300s
+      idle: 300s

--- a/ingress/manifests/panel.yaml.tpl
+++ b/ingress/manifests/panel.yaml.tpl
@@ -1,0 +1,20 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: panel-httpproxy
+  namespace: ${environment.namespace}
+spec:
+  virtualhost:
+    fqdn: panel.${var.hostname}
+    tls:
+      secretName: panel.${var.hostname}-tls
+  routes:
+  - conditions:
+    - prefix: /
+    services:
+    - name: panel-app
+      port: 5006
+    enableWebsockets: true
+    timeoutPolicy:
+      response: 300s
+      idle: 300s


### PR DESCRIPTION
### Summary

Import ingress manifests and associated garden actions for frontend/dashboards and panel-dashboards.

Submitting as draft until the [update](https://github.com/RTIInternational/teehr-cloud-core/pull/9) is available in `teehr-cloud-core`, at which point this PR will be updated with the new submodule commit.

### Testing

Temporarily linked the `teehr-cloud-core` submodule to the PR branch and ran a local deployment.  Verified that the local dashboard and panel URLs were accessible.