### PR TITLE
Handle primary timestep durations in forecast dashboard

### DIFF
--- a/frontend/src/components/common/Navbar.jsx
+++ b/frontend/src/components/common/Navbar.jsx
@@ -124,7 +124,7 @@ const Navbar = () => {
   };
 
   return (
-    <nav className="navbar navbar-expand-lg navbar-dark bg-primary">
+    <nav className="navbar navbar-expand-lg navbar-dark bg-primary" style={{ zIndex: 1300 }}>
       <div className="container-fluid px-4 d-flex align-items-center">
         <div className="navbar-brand me-3 d-flex align-items-center gap-2">
           <Link to="/" className="d-inline-flex align-items-center" aria-label="TEEHR-Cloud Home">

--- a/frontend/src/components/common/PlotlyChart.jsx
+++ b/frontend/src/components/common/PlotlyChart.jsx
@@ -11,27 +11,32 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
     const primaryTraces = [];
     const secondaryTraces = [];
 
-    // Primary trace (observations)
+    // Primary trace(s) - one trace per series, observations rendered last (on top)
     if (primaryData?.length > 0) {
-      // Take the first series for primary data
-      const primarySeries = primaryData[0];
-      if (primarySeries?.timeseries?.length > 0) {
-        const configName = primarySeries.configuration_name || 'USGS';
-        primaryTraces.push({
-          x: primarySeries.timeseries.map(d => d.value_time),
-          y: primarySeries.timeseries.map(d => d.value),
-          name: 'Observed (' + configName + ')',
-          type: 'scatter',
-          mode: 'lines',
-          line: { color: '#000000', width: 2.5 },
-          showlegend: true,
-          hovertemplate: 
-            '<b>%{fullData.name}</b><br>' +
-            'Date: %{x}<br>' +
-            `${formatVariableName(primarySeries.variable_name || filters.variable)}: %{y}${primarySeries.unit_name ? ' ' + formatUnitName(primarySeries.unit_name) : ''}<br>` +
-            '<extra></extra>'
-        });
-      }
+      const primaryColors = ['#000000', '#444444', '#1a1a6e', '#6e1a1a'];
+      primaryData.forEach((series, index) => {
+        if (series?.timeseries?.length > 0) {
+          const configName = series.configuration_name || 'USGS';
+          const varName = formatVariableName(series.variable_name || filters?.variable);
+          const traceName = series.duration_token
+            ? `Observed (${configName}) - ${series.duration_token}`
+            : `Observed (${configName})`;
+          primaryTraces.push({
+            x: series.timeseries.map(d => d.value_time),
+            y: series.timeseries.map(d => d.value),
+            name: traceName,
+            type: 'scatter',
+            mode: 'lines',
+            line: { color: primaryColors[index % primaryColors.length], width: 2.5 },
+            showlegend: true,
+            hovertemplate:
+              '<b>%{fullData.name}</b><br>' +
+              'Date: %{x}<br>' +
+              `${varName}: %{y}${series.unit_name ? ' ' + formatUnitName(series.unit_name) : ''}<br>` +
+              '<extra></extra>'
+          });
+        }
+      });
     }
 
     // Secondary trace(s) - create a trace for each series

--- a/frontend/src/components/common/PlotlyChart.jsx
+++ b/frontend/src/components/common/PlotlyChart.jsx
@@ -18,9 +18,7 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
         if (series?.timeseries?.length > 0) {
           const configName = series.configuration_name || 'USGS';
           const varName = formatVariableName(series.variable_name || filters?.variable);
-          const traceName = series.duration_token
-            ? `Observed (${configName}) - ${series.duration_token}`
-            : `Observed (${configName})`;
+          const traceName = `Observed (${configName})`;
           primaryTraces.push({
             x: series.timeseries.map(d => d.value_time),
             y: series.timeseries.map(d => d.value),
@@ -52,7 +50,7 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
         { r: 253, g: 126, b: 20 },  // #fd7e14 orange
         { r: 32, g: 201, b: 151 }   // #20c997 teal
       ];
-      
+
       // First pass: group series by configuration_name and collect reference_times
       const configGroups = new Map();
       secondaryData.forEach(series => {
@@ -66,7 +64,7 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
           }
         }
       });
-      
+
       // Assign colors to each configuration and sort reference_times
       const configColorMap = new Map();
       const configRefTimesMap = new Map();
@@ -78,7 +76,7 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
         configRefTimesMap.set(configName, sortedRefTimes);
         colorIndex++;
       });
-      
+
       // Helper to calculate opacity based on reference_time position
       const getOpacity = (configName, refTime) => {
         const sortedRefTimes = configRefTimesMap.get(configName);
@@ -92,14 +90,14 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
       };
 
       const getLegendGroup = (configName) => `forecast:${configName || 'unknown'}`;
-      
+
       secondaryData.forEach(series => {
         if (series?.timeseries?.length > 0) {
           const key = `${series.configuration_name}|${series.variable_name}|${series.reference_time}`;
-          
+
           if (!traceMap.has(key)) {
             const configName = series.configuration_name;
-            
+
             // Display trace name with reference_time details in hover, but keep legend simple
             const traceName = configName;
             let hoverName = configName;
@@ -116,12 +114,12 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
                 hoverName = `${configName} (${series.reference_time})`;
               }
             }
-            
+
             // Get base color for this configuration and calculate opacity
             const baseColor = configColorMap.get(configName) || baseColors[0];
             const opacity = getOpacity(configName, series.reference_time);
             const rgbaColor = `rgba(${baseColor.r}, ${baseColor.g}, ${baseColor.b}, ${opacity})`;
-            
+
             const trace = {
               x: series.timeseries.map(d => d.value_time),
               y: series.timeseries.map(d => d.value),
@@ -129,16 +127,16 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
               legendgroup: getLegendGroup(configName),
               type: 'scatter',
               mode: 'lines',
-              line: { 
-                color: rgbaColor, 
-                width: 2 
+              line: {
+                color: rgbaColor,
+                width: 2
               },
               showlegend: false, // Will be set to true for last occurrence only
-              hovertemplate: 
+              hovertemplate:
                 '<b>' + hoverName + '</b><br>' +
                 'Date: %{x}<br>' +
                 `${formatVariableName(series.variable_name || filters.variable)}: %{y}${series.unit_name ? ' ' + formatUnitName(series.unit_name) : ''}<br>` +
-                (series.reference_time && series.reference_time !== 'null' ? 
+                (series.reference_time && series.reference_time !== 'null' ?
                   `Reference: ${series.reference_time}<br>` : '') +
                 '<extra></extra>'
             };
@@ -147,7 +145,7 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
           }
         }
       });
-      
+
       // Set showlegend only for the last trace of each configuration
       const lastTraceIndexPerConfig = new Map();
       secondaryTraces.forEach((trace, index) => {
@@ -167,15 +165,15 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
     }
 
     const yAxisTitle = getYAxisTitle(primaryData, secondaryData, filters);
-    
+
     const layout = {
-      xaxis: { 
+      xaxis: {
         title: {
           text: 'Date',
           font: { size: 14 }
         }
       },
-      yaxis: { 
+      yaxis: {
         title: {
           text: yAxisTitle,
           font: { size: 14 }
@@ -195,7 +193,7 @@ const PlotlyChart = ({ primaryData, secondaryData, selectedLocation, filters, he
       }
     };
 
-    Plotly.react(plotRef.current, traces, layout, { 
+    Plotly.react(plotRef.current, traces, layout, {
       responsive: true,
       displayModeBar: 'hover'
     });

--- a/frontend/src/components/common/dashboard/TimeseriesControls.jsx
+++ b/frontend/src/components/common/dashboard/TimeseriesControls.jsx
@@ -81,7 +81,7 @@ const TimeseriesControls = ({
         {/* Inst observations timestep */}
         <Col md={6}>
           <Form.Group>
-            <Form.Label className="small fw-bold">Obs timestep (where available)</Form.Label>
+            <Form.Label className="small fw-bold">Obs timestep (if available)</Form.Label>
             <Form.Select
               size="sm"
               value={timeseriesFilters.duration || ''}

--- a/frontend/src/components/common/dashboard/TimeseriesControls.jsx
+++ b/frontend/src/components/common/dashboard/TimeseriesControls.jsx
@@ -1,23 +1,24 @@
 import { Form, Row, Col, Button } from 'react-bootstrap';
 import MultiSelectDropdown from '../MultiSelectDropdown';
+import { DURATION_NAME_TO_ISO } from '../../../utils/durationUtils';
 
-const TimeseriesControls = ({ 
-  state, 
-  timeseriesFilters, 
-  updateTimeseriesFilters, 
-  loadTimeseries, 
+const TimeseriesControls = ({
+  state,
+  timeseriesFilters,
+  updateTimeseriesFilters,
+  loadTimeseries,
   selectedLocation,
   mapFilters,
   onViewModeChange
 }) => {
-  
+
   const handleFilterChange = (field, value) => {
     updateTimeseriesFilters({ [field]: value });
   };
 
   const handleLoadData = async () => {
     if (!selectedLocation?.primary_location_id) return;
-    
+
     await loadTimeseries({
       primary_location_id: selectedLocation.primary_location_id,
       configurations: timeseriesFilters.configurations,
@@ -25,9 +26,10 @@ const TimeseriesControls = ({
       start_date: timeseriesFilters.start_date,
       end_date: timeseriesFilters.end_date,
       reference_start_date: timeseriesFilters.reference_start_date,
-      reference_end_date: timeseriesFilters.reference_end_date
+      reference_end_date: timeseriesFilters.reference_end_date,
+      duration: timeseriesFilters.duration
     });
-    
+
     // Switch to plot view after loading data
     if (onViewModeChange) {
       onViewModeChange('plot');
@@ -35,8 +37,8 @@ const TimeseriesControls = ({
   };
 
   // Get selected configurations or use map configuration as fallback
-  const selectedConfigurations = timeseriesFilters.configurations?.length > 0 
-    ? timeseriesFilters.configurations 
+  const selectedConfigurations = timeseriesFilters.configurations?.length > 0
+    ? timeseriesFilters.configurations
     : (mapFilters.configuration ? [mapFilters.configuration] : []);
 
   return (
@@ -44,7 +46,7 @@ const TimeseriesControls = ({
       <Form className="flex-grow-1">
         <Row className="g-2 align-content-start">
           {/* Configuration - Multi-select */}
-          <Col md={6}>
+          <Col md={12}>
             <Form.Group>
               <Form.Label className="small fw-bold">Configurations</Form.Label>
               <MultiSelectDropdown
@@ -71,6 +73,23 @@ const TimeseriesControls = ({
                 <option key={variable} value={variable}>
                   {variable}
                 </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Col>
+
+        {/* Inst observations timestep */}
+        <Col md={6}>
+          <Form.Group>
+            <Form.Label className="small fw-bold">Obs timestep (where available)</Form.Label>
+            <Form.Select
+              size="sm"
+              value={timeseriesFilters.duration || ''}
+              disabled={!timeseriesFilters.variable?.endsWith('_inst')}
+              onChange={(e) => handleFilterChange('duration', e.target.value)}
+            >
+              {Object.entries(DURATION_NAME_TO_ISO).map(([label, iso]) => (
+                <option key={iso} value={iso}>{label}</option>
               ))}
             </Form.Select>
           </Form.Group>
@@ -131,9 +150,9 @@ const TimeseriesControls = ({
         {/* Load Button */}
         <Col md={12}>
           <div className="d-flex justify-content-end mt-2">
-            <Button 
-              variant="primary" 
-              size="sm" 
+            <Button
+              variant="primary"
+              size="sm"
               onClick={handleLoadData}
               disabled={!selectedLocation?.primary_location_id || !timeseriesFilters.configurations?.length || !timeseriesFilters.variable}
             >

--- a/frontend/src/components/common/dashboard/TimeseriesControls.jsx
+++ b/frontend/src/components/common/dashboard/TimeseriesControls.jsx
@@ -85,7 +85,7 @@ const TimeseriesControls = ({
             <Form.Select
               size="sm"
               value={timeseriesFilters.duration || ''}
-              disabled={!timeseriesFilters.variable?.endsWith('_inst')}
+              disabled={!(timeseriesFilters.variable || mapFilters.variable)?.endsWith('_inst')}
               onChange={(e) => handleFilterChange('duration', e.target.value)}
             >
               {Object.entries(DURATION_NAME_TO_ISO).map(([label, iso]) => (

--- a/frontend/src/components/dashboards/forecast/ForecastTimeseriesControls.jsx
+++ b/frontend/src/components/dashboards/forecast/ForecastTimeseriesControls.jsx
@@ -86,7 +86,7 @@ const ForecastTimeseriesControls = ({
                 <Form.Group>
                   <Form.Label className="small fw-bold">Variable</Form.Label>
                   <MultiSelectDropdown
-                    options={Array.isArray(state.variables) ? state.variables : []}
+                    options={Array.isArray(state.primaryVariables) ? state.primaryVariables : []}
                     selected={primaryFilters.variables}
                     onChange={(selected) => handlePrimaryFilterChange('variables', selected)}
                     allSelectedText="All variables"

--- a/frontend/src/components/dashboards/forecast/ForecastTimeseriesControls.jsx
+++ b/frontend/src/components/dashboards/forecast/ForecastTimeseriesControls.jsx
@@ -98,7 +98,7 @@ const ForecastTimeseriesControls = ({
               </Col>
               <Col md={6}>
                 <Form.Group>
-                  <Form.Label className="small fw-bold">Obs timestep (where available)</Form.Label>
+                  <Form.Label className="small fw-bold">Obs timestep (if available)</Form.Label>
                   <Form.Select
                     size="sm"
                     value={primaryFilters.duration || ''}

--- a/frontend/src/components/dashboards/forecast/ForecastTimeseriesControls.jsx
+++ b/frontend/src/components/dashboards/forecast/ForecastTimeseriesControls.jsx
@@ -98,7 +98,7 @@ const ForecastTimeseriesControls = ({
               </Col>
               <Col md={6}>
                 <Form.Group>
-                  <Form.Label className="small fw-bold">Inst timestep (where available)</Form.Label>
+                  <Form.Label className="small fw-bold">Obs timestep (where available)</Form.Label>
                   <Form.Select
                     size="sm"
                     value={primaryFilters.duration || ''}

--- a/frontend/src/components/dashboards/forecast/ForecastTimeseriesControls.jsx
+++ b/frontend/src/components/dashboards/forecast/ForecastTimeseriesControls.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Form, Row, Col, Button, Tabs, Tab } from 'react-bootstrap';
 import MultiSelectDropdown from '../../common/MultiSelectDropdown';
+import { toDisplayVariableName, fromDisplayVariableName, isTimestepVariable, DURATION_NAME_TO_ISO } from '../../../utils/durationUtils';
 
 const ForecastTimeseriesControls = ({
   state,
@@ -17,7 +18,8 @@ const ForecastTimeseriesControls = ({
     return {
       variables: nested.variables ?? (timeseriesFilters?.variable ? [timeseriesFilters.variable] : []),
       start_date: nested.start_date ?? timeseriesFilters?.start_date ?? null,
-      end_date: nested.end_date ?? timeseriesFilters?.end_date ?? null
+      end_date: nested.end_date ?? timeseriesFilters?.end_date ?? null,
+      duration: nested.duration ?? null
     };
   }, [timeseriesFilters]);
 
@@ -82,16 +84,31 @@ const ForecastTimeseriesControls = ({
         >
           <Tab eventKey="observations" title="Observations (Primary)">
             <Row className="g-2">
-              <Col md={12}>
+              <Col md={6}>
                 <Form.Group>
                   <Form.Label className="small fw-bold">Variable</Form.Label>
                   <MultiSelectDropdown
-                    options={Array.isArray(state.primaryVariables) ? state.primaryVariables : []}
-                    selected={primaryFilters.variables}
-                    onChange={(selected) => handlePrimaryFilterChange('variables', selected)}
+                    options={(Array.isArray(state.primaryVariables) ? state.primaryVariables : []).map(toDisplayVariableName)}
+                    selected={(primaryFilters.variables || []).map(toDisplayVariableName)}
+                    onChange={(displaySelected) => handlePrimaryFilterChange('variables', displaySelected.map(fromDisplayVariableName))}
                     allSelectedText="All variables"
                     noneSelectedText="Select variables..."
                   />
+                </Form.Group>
+              </Col>
+              <Col md={6}>
+                <Form.Group>
+                  <Form.Label className="small fw-bold">Inst timestep (where available)</Form.Label>
+                  <Form.Select
+                    size="sm"
+                    value={primaryFilters.duration || ''}
+                    disabled={!(primaryFilters.variables || []).some(isTimestepVariable)}
+                    onChange={(e) => handlePrimaryFilterChange('duration', e.target.value)}
+                  >
+                    {Object.entries(DURATION_NAME_TO_ISO).map(([label, iso]) => (
+                      <option key={iso} value={iso}>{label}</option>
+                    ))}
+                  </Form.Select>
                 </Form.Group>
               </Col>
 

--- a/frontend/src/components/dashboards/forecast/useForecastData.js
+++ b/frontend/src/components/dashboards/forecast/useForecastData.js
@@ -6,21 +6,21 @@ import { useForecastDataFetching } from '../../../hooks/useForecastDataFetching'
  * Handles the forecast_metrics_by_location table specifically
  */
 export const useForecastData = () => {
-  const { loadConfigurations, loadVariables, loadTableProperties, loadLocations, loadTimeseries, loadLocationMetrics, ...otherHooks } = useForecastDataFetching();
-  
+  const { loadConfigurations, loadVariables, loadPrimaryVariables, loadTableProperties, loadLocations, loadTimeseries, loadLocationMetrics, ...otherHooks } = useForecastDataFetching();
+
   // Table names for forecast dashboard
   const TABLE_NAMES = ['fcst_metrics_by_location', 'fcst_metrics_by_lead_time_bins'];
-  
+
   // Load configurations for forecast metrics
   const loadForecastConfigurations = useCallback(async () => {
     return loadConfigurations(TABLE_NAMES[0]); // Use location table for configurations
   }, [loadConfigurations]);
-  
-  // Load variables for forecast metrics  
+
+  // Load variables for forecast metrics
   const loadForecastVariables = useCallback(async () => {
     return loadVariables(TABLE_NAMES[0]); // Use location table for variables
   }, [loadVariables]);
-  
+
   // Load table properties for forecast metrics
   const loadForecastTableProperties = useCallback(async () => {
     return loadTableProperties(TABLE_NAMES);
@@ -31,30 +31,31 @@ export const useForecastData = () => {
     return loadLocations(filters, TABLE_NAMES[0]); // Use location table for map
   }, [loadLocations]);
 
-  // Load timeseries with forecast table context  
+  // Load timeseries with forecast table context
   const loadForecastTimeseries = useCallback(async (filters = {}) => {
     return loadTimeseries({ ...filters, table: TABLE_NAMES[0] }); // Use location table for timeseries
   }, [loadTimeseries]);
-  
+
   // Load location metrics with forecast table context
   const loadForecastLocationMetrics = useCallback(async (primaryLocationId, selectedTable = TABLE_NAMES[0]) => {
     return loadLocationMetrics(primaryLocationId, selectedTable);
   }, [loadLocationMetrics]);
-  
+
   // Initialize all forecast data
   const initializeForecastData = useCallback(async () => {
     try {
       await Promise.all([
         loadForecastConfigurations(),
-        loadForecastVariables(), 
+        loadForecastVariables(),
+        loadPrimaryVariables(),
         loadForecastTableProperties()
       ]);
     } catch (error) {
       console.error('Failed to initialize forecast data:', error);
       throw error;
     }
-  }, [loadForecastConfigurations, loadForecastVariables, loadForecastTableProperties]);
-  
+  }, [loadForecastConfigurations, loadForecastVariables, loadPrimaryVariables, loadForecastTableProperties]);
+
   return {
     ...otherHooks,
     loadConfigurations: loadForecastConfigurations,

--- a/frontend/src/config/dashboardDefaults.js
+++ b/frontend/src/config/dashboardDefaults.js
@@ -19,7 +19,10 @@ export const RETROSPECTIVE_DASHBOARD_DEFAULTS = {
 
   // Default date range for retrospective analysis
   defaultStartDate: '2020-01-01T00:00',
-  defaultEndDate: '2020-12-31T23:59'
+  defaultEndDate: '2020-12-31T23:59',
+
+  // Default duration for the Observations (primary timeseries) timestep control
+  preferredObservationsDuration: 'PT1H'
 };
 
 export const FORECAST_DASHBOARD_DEFAULTS = {

--- a/frontend/src/config/dashboardDefaults.js
+++ b/frontend/src/config/dashboardDefaults.js
@@ -30,7 +30,11 @@ export const FORECAST_DASHBOARD_DEFAULTS = {
   preferredVariable: 'streamflow_hourly_inst',
 
   // Default metric for map coloring
-  defaultMetricName: 'relative_bias'
+  defaultMetricName: 'relative_bias',
+
+  // Default variable and duration for the Observations (primary timeseries) controls
+  preferredObservationsVariable: 'streamflow_none_inst',
+  preferredObservationsDuration: 'PT1H'
 };
 
 export const DATA_DASHBOARD_DEFAULTS = {

--- a/frontend/src/context/ForecastDashboardContext.jsx
+++ b/frontend/src/context/ForecastDashboardContext.jsx
@@ -14,21 +14,22 @@ const getToday = () => {
   return date.toISOString().slice(0, 16); // Format: YYYY-MM-DDTHH:MM
 };
 
-// Initial state for forecast dashboard  
+// Initial state for forecast dashboard
 const initialForecastState = {
   // Data
   locations: { features: [] },
   configurations: [],
   variables: [],
+  primaryVariables: [],
   tableProperties: {}, // Will contain { "table_name": { metrics: [], group_by: [], description: "" } }
-  
+
   // Map filters (original structure)
   mapFilters: {
     configuration: null,
     variable: null,
     metricName: 'relative_bias'
   },
-  
+
   // Timeseries filters (forecast-specific defaults)
   timeseriesFilters: {
     primary: {
@@ -43,28 +44,28 @@ const initialForecastState = {
       reference_end_date: getToday()
     }
   },
-  
+
   // Selected location
   selectedLocation: null,
-  
+
   // Timeseries data (structured as expected by components)
   timeseriesData: {
     primary: [],
     secondary: []
   },
-  
+
   // Location metrics
   locationMetrics: [],
-  
+
   // Loading states
   locationsLoading: false,
   timeseriesLoading: false,
   metricsLoading: false,
   tablePropertiesLoading: false,
-  
+
   // Map state
   mapLoaded: false,
-  
+
   // Error state
   error: null
 };
@@ -75,30 +76,31 @@ export const ActionTypes = {
   SET_LOCATIONS: 'SET_LOCATIONS',
   SET_CONFIGURATIONS: 'SET_CONFIGURATIONS',
   SET_VARIABLES: 'SET_VARIABLES',
+  SET_PRIMARY_VARIABLES: 'SET_PRIMARY_VARIABLES',
   SET_TABLE_PROPERTIES: 'SET_TABLE_PROPERTIES',
-  
+
   // Filter updates
   UPDATE_MAP_FILTERS: 'UPDATE_MAP_FILTERS',
   UPDATE_TIMESERIES_FILTERS: 'UPDATE_TIMESERIES_FILTERS',
-  
+
   // Location selection
   SELECT_LOCATION: 'SELECT_LOCATION',
-  
+
   // Timeseries data
   SET_PRIMARY_TIMESERIES: 'SET_PRIMARY_TIMESERIES',
   SET_SECONDARY_TIMESERIES: 'SET_SECONDARY_TIMESERIES',
   CLEAR_TIMESERIES: 'CLEAR_TIMESERIES',
-  
+
   // Location metrics
   SET_LOCATION_METRICS: 'SET_LOCATION_METRICS',
   CLEAR_LOCATION_METRICS: 'CLEAR_LOCATION_METRICS',
-  
+
   // Loading states
   SET_LOADING: 'SET_LOADING',
-  
+
   // Map state
   SET_MAP_LOADED: 'SET_MAP_LOADED',
-  
+
   // Error handling
   SET_ERROR: 'SET_ERROR',
   CLEAR_ERROR: 'CLEAR_ERROR'
@@ -113,7 +115,7 @@ const forecastDashboardReducer = (state, action) => {
         locations: action.payload,
         locationsLoading: false
       };
-      
+
     case ActionTypes.SET_CONFIGURATIONS: {
       const configurations = Array.isArray(action.payload) ? action.payload : [];
       const defaultConfig = selectDefault(FORECAST_DASHBOARD_DEFAULTS.preferredConfiguration, configurations);
@@ -136,7 +138,7 @@ const forecastDashboardReducer = (state, action) => {
         }
       };
     }
-      
+
     case ActionTypes.SET_VARIABLES: {
       const variables = Array.isArray(action.payload) ? action.payload : [];
       const defaultVariable = selectDefault(FORECAST_DASHBOARD_DEFAULTS.preferredVariable, variables);
@@ -165,7 +167,12 @@ const forecastDashboardReducer = (state, action) => {
         }
       };
     }
-      
+
+    case ActionTypes.SET_PRIMARY_VARIABLES: {
+      const primaryVariables = Array.isArray(action.payload) ? action.payload : [];
+      return { ...state, primaryVariables };
+    }
+
     case ActionTypes.SET_TABLE_PROPERTIES: {
       const tableProperties = action.payload || {};
       return {
@@ -174,7 +181,7 @@ const forecastDashboardReducer = (state, action) => {
         tablePropertiesLoading: false
       };
     }
-      
+
     case ActionTypes.UPDATE_MAP_FILTERS:
       // Keep timeseries defaults in sync with map display filters.
       // This mirrors retrospective behavior where map filter changes reset
@@ -207,7 +214,7 @@ const forecastDashboardReducer = (state, action) => {
           ...mapTimeseriesSync
         }
       };
-      
+
     case ActionTypes.UPDATE_TIMESERIES_FILTERS: {
       // Support both nested ({ primary, secondary }) and legacy flat payloads.
       const { primary, secondary, ...legacy } = action.payload || {};
@@ -257,13 +264,13 @@ const forecastDashboardReducer = (state, action) => {
         }
       };
     }
-      
+
     case ActionTypes.SELECT_LOCATION:
       return {
         ...state,
         selectedLocation: action.payload
       };
-      
+
     case ActionTypes.SET_PRIMARY_TIMESERIES:
       return {
         ...state,
@@ -272,7 +279,7 @@ const forecastDashboardReducer = (state, action) => {
           primary: action.payload
         }
       };
-      
+
     case ActionTypes.SET_SECONDARY_TIMESERIES:
       return {
         ...state,
@@ -282,7 +289,7 @@ const forecastDashboardReducer = (state, action) => {
         },
         timeseriesLoading: false
       };
-      
+
     case ActionTypes.CLEAR_TIMESERIES:
       return {
         ...state,
@@ -291,7 +298,7 @@ const forecastDashboardReducer = (state, action) => {
           secondary: []
         }
       };
-      
+
     case ActionTypes.SET_LOADING: {
       // Map shorthand keys to actual state property names
       const loadingUpdates = {};
@@ -318,39 +325,39 @@ const forecastDashboardReducer = (state, action) => {
         ...loadingUpdates
       };
     }
-      
+
     case ActionTypes.SET_MAP_LOADED:
       return {
         ...state,
         mapLoaded: action.payload
       };
-      
+
     case ActionTypes.SET_ERROR:
       return {
         ...state,
         error: action.payload
       };
-      
+
     case ActionTypes.CLEAR_ERROR:
       return {
         ...state,
         error: null
       };
-      
+
     case ActionTypes.SET_LOCATION_METRICS:
       return {
         ...state,
         locationMetrics: action.payload,
         metricsLoading: false
       };
-      
+
     case ActionTypes.CLEAR_LOCATION_METRICS:
       return {
         ...state,
         locationMetrics: [],
         metricsLoading: false
       };
-      
+
     default:
       return state;
   }
@@ -362,7 +369,7 @@ const ForecastDashboardContext = createContext();
 // Provider component
 export const ForecastDashboardProvider = ({ children }) => {
   const [state, dispatch] = useReducer(forecastDashboardReducer, initialForecastState);
-  
+
   return (
     <ForecastDashboardContext.Provider value={{ state, dispatch }}>
       {children}

--- a/frontend/src/context/ForecastDashboardContext.jsx
+++ b/frontend/src/context/ForecastDashboardContext.jsx
@@ -33,9 +33,10 @@ const initialForecastState = {
   // Timeseries filters (forecast-specific defaults)
   timeseriesFilters: {
     primary: {
-      variables: [],
+      variables: [FORECAST_DASHBOARD_DEFAULTS.preferredObservationsVariable],
       start_date: getTenDaysAgo(),
-      end_date: getToday()
+      end_date: getToday(),
+      duration: FORECAST_DASHBOARD_DEFAULTS.preferredObservationsDuration
     },
     secondary: {
       configurations: [], // Array for multi-select
@@ -152,12 +153,9 @@ const forecastDashboardReducer = (state, action) => {
         },
         timeseriesFilters: {
           ...state.timeseriesFilters,
-          primary: {
-            ...state.timeseriesFilters.primary,
-            variables: state.timeseriesFilters.primary?.variables?.length > 0
-              ? state.timeseriesFilters.primary.variables
-              : (defaultVariable ? [defaultVariable] : [])
-          },
+          // primary.variables is intentionally NOT set here — it is only populated
+          // from SET_PRIMARY_VARIABLES (Observations dropdown) to avoid passing
+          // fcst_metrics variable names (e.g. streamflow_6hr_inst) to duration parsing.
           secondary: {
             ...state.timeseriesFilters.secondary,
             variables: state.timeseriesFilters.secondary?.variables?.length > 0
@@ -170,7 +168,21 @@ const forecastDashboardReducer = (state, action) => {
 
     case ActionTypes.SET_PRIMARY_VARIABLES: {
       const primaryVariables = Array.isArray(action.payload) ? action.payload : [];
-      return { ...state, primaryVariables };
+      return {
+        ...state,
+        primaryVariables,
+        // Initialize primary.variables to the first available option if not yet set.
+        // This is the only place primary.variables is ever auto-populated.
+        timeseriesFilters: {
+          ...state.timeseriesFilters,
+          primary: {
+            ...state.timeseriesFilters.primary,
+            variables: state.timeseriesFilters.primary?.variables?.length > 0
+              ? state.timeseriesFilters.primary.variables
+              : (primaryVariables.length > 0 ? [primaryVariables[0]] : [])
+          }
+        }
+      };
     }
 
     case ActionTypes.SET_TABLE_PROPERTIES: {
@@ -194,10 +206,8 @@ const forecastDashboardReducer = (state, action) => {
         };
       }
       if (action.payload.variable !== undefined) {
-        mapTimeseriesSync.primary = {
-          ...state.timeseriesFilters.primary,
-          variables: action.payload.variable ? [action.payload.variable] : []
-        };
+        // primary.variables is NOT synced from the map variable — it is controlled
+        // exclusively by the Observations dropdown (state.primaryVariables).
         mapTimeseriesSync.secondary = {
           ...(mapTimeseriesSync.secondary || state.timeseriesFilters.secondary),
           variables: action.payload.variable ? [action.payload.variable] : []

--- a/frontend/src/context/RetrospectiveDashboardContext.jsx
+++ b/frontend/src/context/RetrospectiveDashboardContext.jsx
@@ -28,7 +28,8 @@ const initialRetrospectiveState = {
     start_date: DEFAULT_START_DATE,
     end_date: DEFAULT_END_DATE,
     reference_start_date: null,
-    reference_end_date: null
+    reference_end_date: null,
+    duration: RETROSPECTIVE_DASHBOARD_DEFAULTS.preferredObservationsDuration
   },
   
   // Selected location

--- a/frontend/src/hooks/useForecastDataFetching.js
+++ b/frontend/src/hooks/useForecastDataFetching.js
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useForecastDashboard, ActionTypes } from '../context/ForecastDashboardContext.jsx';
 import { apiService } from '../services/api';
 import { extractTableProperties } from '../utils/ogcTransformers';
+import { groupVariablesByDuration, toPrimaryVariableName, ISO_TO_DURATION_NAME, expandPrimaryVariables } from '../utils/durationUtils';
 
 // Custom hooks for forecast dashboard data fetching
 export const useForecastDataFetching = () => {
@@ -31,6 +32,16 @@ export const useForecastDataFetching = () => {
     }
   }, [dispatch]);
   
+  // Load primary_timeseries variable names and expand them using DURATION_NAME_TO_ISO
+  const loadPrimaryVariables = useCallback(async () => {
+    try {
+      const rawVariables = await apiService.getVariables('primary_timeseries');
+      dispatch({ type: ActionTypes.SET_PRIMARY_VARIABLES, payload: expandPrimaryVariables(rawVariables) });
+    } catch (error) {
+      dispatch({ type: ActionTypes.SET_ERROR, payload: `Failed to load primary variables: ${error.message}` });
+    }
+  }, [dispatch]);
+
   // Load table properties (batch) from queryables
   const loadTableProperties = useCallback(async (tables) => {
     try {
@@ -120,21 +131,40 @@ export const useForecastDataFetching = () => {
         throw new Error('Missing required parameters: primary_location_id, primary.variables, secondary.variables, and secondary.configurations are required');
       }
 
-      // Load primary data (USGS observations)
-      const primaryData = await apiService.getPrimaryTimeseries(primary_location_id, {
-        variable: primaryFilters.variables,
-        start_date: primaryFilters.start_date,
-        end_date: primaryFilters.end_date
-      });
-      dispatch({ type: ActionTypes.SET_PRIMARY_TIMESERIES, payload: primaryData });
+      // Group variables by duration and issue one call per unique duration group.
+      // Variables with a non-'inst' statistic (e.g. _mean) have duration=null and
+      // are passed through without a duration filter.
+      const primaryGroups = groupVariablesByDuration(primaryFilters.variables);
+      const secondaryGroups = groupVariablesByDuration(secondaryFilters.variables);
 
-      // Load secondary data with multi-value configuration and variable filters
-      const secondaryData = await apiService.getSecondaryTimeseries(primary_location_id, {
-        variable: secondaryFilters.variables,
-        reference_start_date: secondaryFilters.reference_start_date,
-        reference_end_date: secondaryFilters.reference_end_date,
-        configuration: secondaryFilters.configurations
-      });
+      const [primaryData, secondaryData] = await Promise.all([
+        Promise.all(
+          Array.from(primaryGroups.entries()).map(([duration, variables]) =>
+            apiService.getPrimaryTimeseries(primary_location_id, {
+              variable: variables.map(toPrimaryVariableName),
+              start_date: primaryFilters.start_date,
+              end_date: primaryFilters.end_date,
+              ...(duration && { duration })
+            }).then(results => results.map(series => ({
+              ...series,
+              duration_token: duration ? ISO_TO_DURATION_NAME[duration] : null
+            })))
+          )
+        ).then(results => results.flat()),
+        Promise.all(
+          Array.from(secondaryGroups.entries()).map(([duration, variables]) =>
+            apiService.getSecondaryTimeseries(primary_location_id, {
+              variable: variables,
+              reference_start_date: secondaryFilters.reference_start_date,
+              reference_end_date: secondaryFilters.reference_end_date,
+              configuration: secondaryFilters.configurations,
+              ...(duration && { duration })
+            })
+          )
+        ).then(results => results.flat())
+      ]);
+
+      dispatch({ type: ActionTypes.SET_PRIMARY_TIMESERIES, payload: primaryData });
       dispatch({ type: ActionTypes.SET_SECONDARY_TIMESERIES, payload: secondaryData });
       
     } catch (error) {
@@ -192,6 +222,7 @@ export const useForecastDataFetching = () => {
   return {
     loadConfigurations,
     loadVariables,
+    loadPrimaryVariables,
     loadTableProperties,
     loadLocations,
     loadTimeseries,

--- a/frontend/src/hooks/useForecastDataFetching.js
+++ b/frontend/src/hooks/useForecastDataFetching.js
@@ -7,7 +7,7 @@ import { groupVariablesByDuration, toPrimaryVariableName, ISO_TO_DURATION_NAME, 
 // Custom hooks for forecast dashboard data fetching
 export const useForecastDataFetching = () => {
   const { dispatch } = useForecastDashboard();
-  
+
   // Load configurations (distinct values from database)
   const loadConfigurations = useCallback(async (table) => {
     try {
@@ -19,7 +19,7 @@ export const useForecastDataFetching = () => {
       dispatch({ type: ActionTypes.SET_ERROR, payload: `Failed to load configurations: ${error.message}` });
     }
   }, [dispatch]);
-  
+
   // Load variables (distinct values from database)
   const loadVariables = useCallback(async (table) => {
     try {
@@ -31,7 +31,7 @@ export const useForecastDataFetching = () => {
       dispatch({ type: ActionTypes.SET_ERROR, payload: `Failed to load variables: ${error.message}` });
     }
   }, [dispatch]);
-  
+
   // Load primary_timeseries variable names and expand them using DURATION_NAME_TO_ISO
   const loadPrimaryVariables = useCallback(async () => {
     try {
@@ -47,35 +47,35 @@ export const useForecastDataFetching = () => {
     try {
       dispatch({ type: ActionTypes.SET_LOADING, payload: { tablePropertiesLoading: true } });
       const tableArray = Array.isArray(tables) ? tables : [tables];
-      
+
       const results = await Promise.all(
         tableArray.map(async (table) => {
           const queryables = await apiService.getQueryables(table);
           return { table, properties: extractTableProperties(queryables) };
         })
       );
-      
+
       const tableProperties = results.reduce((acc, { table, properties }) => {
         acc[table] = properties;
         return acc;
       }, {});
-      
+
       dispatch({ type: ActionTypes.SET_TABLE_PROPERTIES, payload: tableProperties });
     } catch (error) {
       dispatch({ type: ActionTypes.SET_ERROR, payload: `Failed to load table properties: ${error.message}` });
     }
   }, [dispatch]);
-  
+
   // Load locations with filtering
   const loadLocations = useCallback(async (filters = {}, table = null) => {
     try {
       dispatch({ type: ActionTypes.SET_LOADING, payload: { locations: true } });
-      
+
       // Use getMetrics for filtered location data with metrics, or getLocations for basic locations
-      const locations = filters.configuration && filters.variable 
+      const locations = filters.configuration && filters.variable
         ? await apiService.getMetrics({ ...filters, table })
         : await apiService.getLocations();
-      
+
       dispatch({ type: ActionTypes.SET_LOCATIONS, payload: locations });
     } catch (error) {
       console.error('useForecastDataFetching: Error loading locations:', error);
@@ -83,14 +83,14 @@ export const useForecastDataFetching = () => {
       dispatch({ type: ActionTypes.SET_ERROR, payload: `Failed to load locations: ${error.message}` });
     }
   }, [dispatch]);
-  
+
   // Load timeseries data
   const loadTimeseries = useCallback(async (filters = {}) => {
     try {
       // Clear existing timeseries data first
       dispatch({ type: ActionTypes.CLEAR_TIMESERIES });
       dispatch({ type: ActionTypes.SET_LOADING, payload: { timeseries: true } });
-      
+
       const {
         primary_location_id,
         primary = {},
@@ -121,7 +121,7 @@ export const useForecastDataFetching = () => {
         reference_start_date: secondary.reference_start_date ?? reference_start_date,
         reference_end_date: secondary.reference_end_date ?? reference_end_date
       };
-      
+
       if (
         !primary_location_id
         || !secondaryFilters.configurations?.length
@@ -135,7 +135,6 @@ export const useForecastDataFetching = () => {
       // Variables with a non-'inst' statistic (e.g. _mean) have duration=null and
       // are passed through without a duration filter.
       const primaryGroups = groupVariablesByDuration(primaryFilters.variables);
-      const secondaryGroups = groupVariablesByDuration(secondaryFilters.variables);
 
       const [primaryData, secondaryData] = await Promise.all([
         Promise.all(
@@ -151,41 +150,36 @@ export const useForecastDataFetching = () => {
             })))
           )
         ).then(results => results.flat()),
-        Promise.all(
-          Array.from(secondaryGroups.entries()).map(([duration, variables]) =>
-            apiService.getSecondaryTimeseries(primary_location_id, {
-              variable: variables,
-              reference_start_date: secondaryFilters.reference_start_date,
-              reference_end_date: secondaryFilters.reference_end_date,
-              configuration: secondaryFilters.configurations,
-              ...(duration && { duration })
-            })
-          )
-        ).then(results => results.flat())
+        apiService.getSecondaryTimeseries(primary_location_id, {
+          variable: secondaryFilters.variables,
+          reference_start_date: secondaryFilters.reference_start_date,
+          reference_end_date: secondaryFilters.reference_end_date,
+          configuration: secondaryFilters.configurations
+        })
       ]);
 
       dispatch({ type: ActionTypes.SET_PRIMARY_TIMESERIES, payload: primaryData });
       dispatch({ type: ActionTypes.SET_SECONDARY_TIMESERIES, payload: secondaryData });
-      
+
     } catch (error) {
       dispatch({ type: ActionTypes.SET_LOADING, payload: { timeseries: false } });
       dispatch({ type: ActionTypes.SET_ERROR, payload: `Failed to load timeseries: ${error.message}` });
     }
   }, [dispatch]);
-  
+
   // Load location-specific metrics
   const loadLocationMetrics = useCallback(async (primaryLocationId, table) => {
     try {
       console.log('Loading metrics for location:', primaryLocationId, 'table:', table);
       dispatch({ type: ActionTypes.SET_LOADING, payload: { metricsLoading: true } });
-      
+
       const metricsData = await apiService.getMetrics({
         primary_location_id: primaryLocationId,
-        table: table 
+        table: table
       });
-      
+
       console.log('Location metrics GeoJSON loaded:', metricsData);
-      
+
       // Extract raw properties from GeoJSON features for pivoting
       let locationData = [];
       if (metricsData?.features && metricsData.features.length > 0) {
@@ -194,7 +188,7 @@ export const useForecastDataFetching = () => {
           return feature.properties || {};
         });
       }
-      
+
       console.log('Raw location data for pivoting:', locationData);
       dispatch({ type: ActionTypes.SET_LOCATION_METRICS, payload: locationData });
       return locationData;
@@ -205,7 +199,7 @@ export const useForecastDataFetching = () => {
       throw error;
     }
   }, [dispatch]);
-  
+
   // Initialize all data
   const initializeData = useCallback(async () => {
     try {
@@ -218,7 +212,7 @@ export const useForecastDataFetching = () => {
       console.error('Failed to initialize data:', error);
     }
   }, [loadConfigurations, loadVariables, loadTableProperties]);
-  
+
   return {
     loadConfigurations,
     loadVariables,
@@ -234,15 +228,15 @@ export const useForecastDataFetching = () => {
 // Custom hook for filter management
 export const useForecastFilters = () => {
   const { state, dispatch } = useForecastDashboard();
-  
+
   const updateMapFilters = useCallback((filters) => {
     dispatch({ type: ActionTypes.UPDATE_MAP_FILTERS, payload: filters });
   }, [dispatch]);
-  
+
   const updateTimeseriesFilters = useCallback((filters) => {
     dispatch({ type: ActionTypes.UPDATE_TIMESERIES_FILTERS, payload: filters });
   }, [dispatch]);
-  
+
   return {
     mapFilters: state.mapFilters,
     timeseriesFilters: state.timeseriesFilters,
@@ -254,7 +248,7 @@ export const useForecastFilters = () => {
 // Custom hook for location selection
 export const useForecastLocationSelection = () => {
   const { state, dispatch } = useForecastDashboard();
-  
+
   const selectLocation = useCallback((location) => {
     dispatch({ type: ActionTypes.SELECT_LOCATION, payload: location });
     // Always clear timeseries when location changes (including deselection)
@@ -262,7 +256,7 @@ export const useForecastLocationSelection = () => {
     // Clear metrics when location changes
     dispatch({ type: ActionTypes.CLEAR_LOCATION_METRICS });
   }, [dispatch]);
-  
+
   return {
     selectedLocation: state.selectedLocation,
     selectLocation

--- a/frontend/src/hooks/useForecastDataFetching.js
+++ b/frontend/src/hooks/useForecastDataFetching.js
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useForecastDashboard, ActionTypes } from '../context/ForecastDashboardContext.jsx';
 import { apiService } from '../services/api';
 import { extractTableProperties } from '../utils/ogcTransformers';
-import { groupVariablesByDuration, toPrimaryVariableName, ISO_TO_DURATION_NAME, expandPrimaryVariables } from '../utils/durationUtils';
+import { isTimestepVariable, ISO_TO_DURATION_NAME } from '../utils/durationUtils';
 
 // Custom hooks for forecast dashboard data fetching
 export const useForecastDataFetching = () => {
@@ -36,7 +36,7 @@ export const useForecastDataFetching = () => {
   const loadPrimaryVariables = useCallback(async () => {
     try {
       const rawVariables = await apiService.getVariables('primary_timeseries');
-      dispatch({ type: ActionTypes.SET_PRIMARY_VARIABLES, payload: expandPrimaryVariables(rawVariables) });
+      dispatch({ type: ActionTypes.SET_PRIMARY_VARIABLES, payload: rawVariables });
     } catch (error) {
       dispatch({ type: ActionTypes.SET_ERROR, payload: `Failed to load primary variables: ${error.message}` });
     }
@@ -112,7 +112,8 @@ export const useForecastDataFetching = () => {
       const primaryFilters = {
         variables: primary.variables ?? legacyVariables,
         start_date: primary.start_date ?? start_date,
-        end_date: primary.end_date ?? end_date
+        end_date: primary.end_date ?? end_date,
+        duration: primary.duration ?? null
       };
 
       const secondaryFilters = {
@@ -131,25 +132,19 @@ export const useForecastDataFetching = () => {
         throw new Error('Missing required parameters: primary_location_id, primary.variables, secondary.variables, and secondary.configurations are required');
       }
 
-      // Group variables by duration and issue one call per unique duration group.
-      // Variables with a non-'inst' statistic (e.g. _mean) have duration=null and
-      // are passed through without a duration filter.
-      const primaryGroups = groupVariablesByDuration(primaryFilters.variables);
+      const hasTimestepVar = primaryFilters.variables?.some(isTimestepVariable);
+      const primaryDuration = hasTimestepVar ? primaryFilters.duration : null;
 
       const [primaryData, secondaryData] = await Promise.all([
-        Promise.all(
-          Array.from(primaryGroups.entries()).map(([duration, variables]) =>
-            apiService.getPrimaryTimeseries(primary_location_id, {
-              variable: variables.map(toPrimaryVariableName),
-              start_date: primaryFilters.start_date,
-              end_date: primaryFilters.end_date,
-              ...(duration && { duration })
-            }).then(results => results.map(series => ({
-              ...series,
-              duration_token: duration ? ISO_TO_DURATION_NAME[duration] : null
-            })))
-          )
-        ).then(results => results.flat()),
+        apiService.getPrimaryTimeseries(primary_location_id, {
+          variable: primaryFilters.variables,
+          start_date: primaryFilters.start_date,
+          end_date: primaryFilters.end_date,
+          ...(primaryDuration && { duration: primaryDuration })
+        }).then(results => results.map(series => ({
+          ...series,
+          duration_token: primaryDuration ? ISO_TO_DURATION_NAME[primaryDuration] : null
+        }))),
         apiService.getSecondaryTimeseries(primary_location_id, {
           variable: secondaryFilters.variables,
           reference_start_date: secondaryFilters.reference_start_date,

--- a/frontend/src/hooks/useRetrospectiveDataFetching.js
+++ b/frontend/src/hooks/useRetrospectiveDataFetching.js
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useRetrospectiveDashboard, ActionTypes } from '../context/RetrospectiveDashboardContext.jsx';
 import { apiService } from '../services/api';
 import { extractTableProperties } from '../utils/ogcTransformers';
+import { toPrimaryVariableName } from '../utils/durationUtils';
 
 // Custom hooks for retrospective dashboard data fetching
 export const useRetrospectiveDataFetching = () => {
@@ -97,17 +98,21 @@ export const useRetrospectiveDataFetching = () => {
         dispatch({ type: ActionTypes.CLEAR_TIMESERIES });
         dispatch({ type: ActionTypes.SET_LOADING, payload: { timeseries: true } });
         
-        const { primary_location_id, configurations, variable, start_date, end_date } = filters;
+        const { primary_location_id, configurations, variable, start_date, end_date, duration } = filters;
         
         if (!primary_location_id || !configurations?.length || !variable) {
           throw new Error('Missing required parameters: primary_location_id, configurations, and variable are required');
         }
   
         // Load primary data (USGS observations)
+        // Convert _inst variable names to primary_timeseries canonical form (e.g. streamflow_hourly_inst -> streamflow_none_inst)
+        // and include duration filter only for instantaneous (_inst) variables
+        const primaryVariable = variable?.endsWith('_inst') ? toPrimaryVariableName(variable) : variable;
         const primaryFilters = {
-          variable,
+          variable: primaryVariable,
           start_date,
-          end_date
+          end_date,
+          ...(variable?.endsWith('_inst') && duration && { duration })
         };
         const primaryData = await apiService.getPrimaryTimeseries(primary_location_id, primaryFilters);
         dispatch({ type: ActionTypes.SET_PRIMARY_TIMESERIES, payload: primaryData });

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -176,6 +176,7 @@ export const apiService = {
     } else if (filters.configuration) {
       params.append('configuration_name', filters.configuration);
     }
+    if (filters.duration) params.append('duration', filters.duration);
     params.append('f', 'timeseries'); // Request timeseries format
 
     return apiCall(`/collections/primary_timeseries/items?${params.toString()}`);
@@ -212,6 +213,7 @@ export const apiService = {
     } else if (filters.variable) {
       params.append('variable_name', filters.variable);
     }
+    if (filters.duration) params.append('duration', filters.duration);
     params.append('f', 'timeseries'); // Request timeseries format
 
     return apiCall(`/collections/secondary_timeseries/items?${params.toString()}`);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -176,7 +176,7 @@ export const apiService = {
     } else if (filters.configuration) {
       params.append('configuration_name', filters.configuration);
     }
-    if (filters.duration) params.append('duration', filters.duration);
+    if (filters.duration) params.append('timestep_duration', filters.duration);
     params.append('f', 'timeseries'); // Request timeseries format
 
     return apiCall(`/collections/primary_timeseries/items?${params.toString()}`);
@@ -213,7 +213,7 @@ export const apiService = {
     } else if (filters.variable) {
       params.append('variable_name', filters.variable);
     }
-    if (filters.duration) params.append('duration', filters.duration);
+    if (filters.duration) params.append('timestep_duration', filters.duration);
     params.append('f', 'timeseries'); // Request timeseries format
 
     return apiCall(`/collections/secondary_timeseries/items?${params.toString()}`);

--- a/frontend/src/utils/durationUtils.js
+++ b/frontend/src/utils/durationUtils.js
@@ -1,0 +1,125 @@
+/**
+ * Mapping of duration name tokens (embedded in variable names) to ISO 8601 duration codes.
+ * Variable names follow the form <variable>_<duration>_<statistic>
+ * (e.g. "streamflow_hourly_inst").
+ *
+ * To support a new duration, add an entry here — no other code changes are needed.
+ */
+export const DURATION_NAME_TO_ISO = {
+  '15min': 'PT15M',
+  'hourly': 'PT1H',
+};
+
+/**
+ * Inverse of DURATION_NAME_TO_ISO — auto-derived so the two maps never diverge.
+ * Maps ISO 8601 duration codes back to their duration name tokens.
+ */
+export const ISO_TO_DURATION_NAME = Object.fromEntries(
+  Object.entries(DURATION_NAME_TO_ISO).map(([name, iso]) => [iso, name])
+);
+
+/**
+ * Parse duration info from a variable name of the form
+ * <variable>_<duration>_<statistic> (e.g. "streamflow_hourly_inst").
+ *
+ * Returns { duration: isoCode } when the statistic token is "inst" and the
+ * duration token is recognised in DURATION_NAME_TO_ISO.
+ * Returns { duration: null } for all non-inst statistics (e.g. _mean, _max).
+ *
+ * Throws if the variable name has fewer than three underscore-separated parts,
+ * or if the statistic is "inst" but the duration token is not in the map.
+ *
+ * @param {string} variableName
+ * @returns {{ duration: string|null }}
+ */
+export function parseVariableInfo(variableName) {
+  const parts = variableName.split('_');
+  if (parts.length < 3) {
+    throw new Error(
+      `Variable name "${variableName}" does not match the expected ` +
+      '<variable>_<duration>_<statistic> format.'
+    );
+  }
+
+  const statistic = parts[parts.length - 1];
+  if (statistic !== 'inst') {
+    return { duration: null };
+  }
+
+  const durationToken = parts[parts.length - 2];
+  const isoCode = DURATION_NAME_TO_ISO[durationToken];
+  if (!isoCode) {
+    throw new Error(
+      `Unrecognised duration token "${durationToken}" in variable "${variableName}". ` +
+      'Add it to DURATION_NAME_TO_ISO in durationUtils.js to support it.'
+    );
+  }
+
+  return { duration: isoCode };
+}
+
+/**
+ * Convert a variable name to its primary_timeseries equivalent by replacing
+ * the duration token with "none" (e.g. "streamflow_hourly_inst" -> "streamflow_none_inst").
+ *
+ * Only applies when the statistic token is "inst". Non-inst variables are returned unchanged.
+ *
+ * @param {string} variableName
+ * @returns {string}
+ */
+export function toPrimaryVariableName(variableName) {
+  const parts = variableName.split('_');
+  if (parts.length < 3) return variableName;
+  if (parts[parts.length - 1] !== 'inst') return variableName;
+  const result = [...parts];
+  result[result.length - 2] = 'none';
+  return result.join('_');
+}
+
+/**
+ * Expand primary_timeseries variable names (e.g. 'streamflow_none_inst') into
+ * all duration variants by replacing the 'none' token with every key in
+ * DURATION_NAME_TO_ISO (e.g. ['streamflow_15min_inst', 'streamflow_hourly_inst']).
+ *
+ * Variables that do not match the <var>_none_inst pattern are returned unchanged.
+ *
+ * @param {string[]} primaryVariableNames
+ * @returns {string[]}
+ */
+export function expandPrimaryVariables(primaryVariableNames) {
+  const durationKeys = Object.keys(DURATION_NAME_TO_ISO);
+  return primaryVariableNames.flatMap(varName => {
+    const parts = varName.split('_');
+    if (
+      parts.length < 3 ||
+      parts[parts.length - 2] !== 'none' ||
+      parts[parts.length - 1] !== 'inst'
+    ) {
+      return [varName];
+    }
+    return durationKeys.map(token => {
+      const result = [...parts];
+      result[result.length - 2] = token;
+      return result.join('_');
+    });
+  });
+}
+
+/**
+ * Group an array of variable names by their ISO 8601 duration code.
+ * Variables whose statistic is not "inst" are grouped under the null key.
+ *
+ * @param {string[]} variables
+ * @returns {Map<string|null, string[]>}
+ */
+export function groupVariablesByDuration(variables) {
+  const groups = new Map();
+  for (const variable of variables) {
+    const { duration } = parseVariableInfo(variable);
+    if (!groups.has(duration)) {
+      groups.set(duration, []);
+    }
+    groups.get(duration).push(variable);
+  }
+  return groups;
+}

--- a/frontend/src/utils/durationUtils.js
+++ b/frontend/src/utils/durationUtils.js
@@ -6,8 +6,8 @@
  * To support a new duration, add an entry here — no other code changes are needed.
  */
 export const DURATION_NAME_TO_ISO = {
-  'Hourly': 'PT1H',
-  '15 min': 'PT15M',
+  'Hourly (inst)': 'PT1H',
+  '15 min (inst)': 'PT15M',
 };
 
 /**
@@ -56,4 +56,23 @@ export function fromDisplayVariableName(displayName) {
  */
 export function isTimestepVariable(rawName) {
   return rawName ? rawName.endsWith('_none_inst') : false;
+}
+
+/**
+ * Convert a duration-specific variable name to its primary_timeseries equivalent
+ * by replacing the duration token with 'none'
+ * (e.g. 'streamflow_hourly_inst' -> 'streamflow_none_inst').
+ *
+ * Only applies when the statistic token is 'inst'. Non-inst variables are returned unchanged.
+ *
+ * @param {string} variableName
+ * @returns {string}
+ */
+export function toPrimaryVariableName(variableName) {
+  const parts = variableName.split('_');
+  if (parts.length < 3) return variableName;
+  if (parts[parts.length - 1] !== 'inst') return variableName;
+  const result = [...parts];
+  result[result.length - 2] = 'none';
+  return result.join('_');
 }

--- a/frontend/src/utils/durationUtils.js
+++ b/frontend/src/utils/durationUtils.js
@@ -6,8 +6,8 @@
  * To support a new duration, add an entry here — no other code changes are needed.
  */
 export const DURATION_NAME_TO_ISO = {
-  '15min': 'PT15M',
-  'hourly': 'PT1H',
+  'Hourly': 'PT1H',
+  '15 min': 'PT15M',
 };
 
 /**
@@ -19,107 +19,41 @@ export const ISO_TO_DURATION_NAME = Object.fromEntries(
 );
 
 /**
- * Parse duration info from a variable name of the form
- * <variable>_<duration>_<statistic> (e.g. "streamflow_hourly_inst").
+ * Convert a raw primary_timeseries variable name to a display name.
+ * Replaces the '_none_inst' suffix with '_inst'.
+ * All other variable names are returned unchanged.
  *
- * Returns { duration: isoCode } when the statistic token is "inst" and the
- * duration token is recognised in DURATION_NAME_TO_ISO.
- * Returns { duration: null } for all non-inst statistics (e.g. _mean, _max).
- *
- * Throws if the variable name has fewer than three underscore-separated parts,
- * or if the statistic is "inst" but the duration token is not in the map.
- *
- * @param {string} variableName
- * @returns {{ duration: string|null }}
- */
-export function parseVariableInfo(variableName) {
-  const parts = variableName.split('_');
-  if (parts.length < 3) {
-    throw new Error(
-      `Variable name "${variableName}" does not match the expected ` +
-      '<variable>_<duration>_<statistic> format.'
-    );
-  }
-
-  const statistic = parts[parts.length - 1];
-  if (statistic !== 'inst') {
-    return { duration: null };
-  }
-
-  const durationToken = parts[parts.length - 2];
-  const isoCode = DURATION_NAME_TO_ISO[durationToken];
-  if (!isoCode) {
-    throw new Error(
-      `Unrecognised duration token "${durationToken}" in variable "${variableName}". ` +
-      'Add it to DURATION_NAME_TO_ISO in durationUtils.js to support it.'
-    );
-  }
-
-  return { duration: isoCode };
-}
-
-/**
- * Convert a variable name to its primary_timeseries equivalent by replacing
- * the duration token with "none" (e.g. "streamflow_hourly_inst" -> "streamflow_none_inst").
- *
- * Only applies when the statistic token is "inst". Non-inst variables are returned unchanged.
- *
- * @param {string} variableName
+ * @param {string} rawName
  * @returns {string}
  */
-export function toPrimaryVariableName(variableName) {
-  const parts = variableName.split('_');
-  if (parts.length < 3) return variableName;
-  if (parts[parts.length - 1] !== 'inst') return variableName;
-  const result = [...parts];
-  result[result.length - 2] = 'none';
-  return result.join('_');
-}
-
-/**
- * Expand primary_timeseries variable names (e.g. 'streamflow_none_inst') into
- * all duration variants by replacing the 'none' token with every key in
- * DURATION_NAME_TO_ISO (e.g. ['streamflow_15min_inst', 'streamflow_hourly_inst']).
- *
- * Variables that do not match the <var>_none_inst pattern are returned unchanged.
- *
- * @param {string[]} primaryVariableNames
- * @returns {string[]}
- */
-export function expandPrimaryVariables(primaryVariableNames) {
-  const durationKeys = Object.keys(DURATION_NAME_TO_ISO);
-  return primaryVariableNames.flatMap(varName => {
-    const parts = varName.split('_');
-    if (
-      parts.length < 3 ||
-      parts[parts.length - 2] !== 'none' ||
-      parts[parts.length - 1] !== 'inst'
-    ) {
-      return [varName];
-    }
-    return durationKeys.map(token => {
-      const result = [...parts];
-      result[result.length - 2] = token;
-      return result.join('_');
-    });
-  });
-}
-
-/**
- * Group an array of variable names by their ISO 8601 duration code.
- * Variables whose statistic is not "inst" are grouped under the null key.
- *
- * @param {string[]} variables
- * @returns {Map<string|null, string[]>}
- */
-export function groupVariablesByDuration(variables) {
-  const groups = new Map();
-  for (const variable of variables) {
-    const { duration } = parseVariableInfo(variable);
-    if (!groups.has(duration)) {
-      groups.set(duration, []);
-    }
-    groups.get(duration).push(variable);
+export function toDisplayVariableName(rawName) {
+  if (rawName && rawName.endsWith('_none_inst')) {
+    return rawName.slice(0, -'_none_inst'.length) + '_inst';
   }
-  return groups;
+  return rawName;
+}
+
+/**
+ * Inverse of toDisplayVariableName.
+ * Converts '_inst' suffix back to '_none_inst'.
+ *
+ * @param {string} displayName
+ * @returns {string}
+ */
+export function fromDisplayVariableName(displayName) {
+  if (displayName && displayName.endsWith('_inst')) {
+    return displayName.slice(0, -'_inst'.length) + '_none_inst';
+  }
+  return displayName;
+}
+
+/**
+ * Returns true when the raw variable name ends with '_none_inst',
+ * indicating it supports timestep duration filtering.
+ *
+ * @param {string} rawName
+ * @returns {boolean}
+ */
+export function isTimestepVariable(rawName) {
+  return rawName ? rawName.endsWith('_none_inst') : false;
 }

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -9,18 +9,19 @@
  */
 export const formatVariableName = (variableName) => {
   if (!variableName) return 'Value';
-  
+
   // Lookup table for variable name overrides
   const variableLookup = {
     'streamflow_hourly_inst': 'Streamflow (Hourly Instantaneous)',
+    'streamflow_none_inst': 'Streamflow (Instantaneous)',
     'streamflow_daily_mean': 'Streamflow (Daily Mean)',
     'precipitation': 'Precipitation',
     'temperature': 'Temperature',
     'water_temperature': 'Water Temperature'
   };
-  
+
   // Return override if exists, otherwise convert snake_case to Title Case
-  return variableLookup[variableName] || 
+  return variableLookup[variableName] ||
     variableName
       .split('_')
       .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
@@ -34,7 +35,7 @@ export const formatVariableName = (variableName) => {
  */
 export const formatUnitName = (unitName) => {
   if (!unitName) return '';
-  
+
   // Lookup table for unit overrides
   const unitLookup = {
     'm3/s': 'm³/s',
@@ -52,7 +53,7 @@ export const formatUnitName = (unitName) => {
     'meters': 'm',
     'feet': 'ft'
   };
-  
+
   // Return override if exists, otherwise return raw string
   return unitLookup[unitName.toLowerCase()] || unitName;
 };
@@ -60,7 +61,7 @@ export const formatUnitName = (unitName) => {
 /**
  * Create a formatted Y-axis title with variable name and units
  * @param {Array} primaryData - Primary timeseries data
- * @param {Array} secondaryData - Secondary timeseries data  
+ * @param {Array} secondaryData - Secondary timeseries data
  * @param {Object} filters - Current filter settings
  * @returns {string} Formatted Y-axis title
  */
@@ -68,7 +69,7 @@ export const getYAxisTitle = (primaryData, secondaryData, filters) => {
   // Try to get unit from the data first
   let unit = null;
   let variable = null;
-  
+
   if (primaryData?.length > 0 && primaryData[0]?.unit_name) {
     unit = primaryData[0].unit_name;
     variable = primaryData[0].variable_name || filters.variable;
@@ -76,15 +77,15 @@ export const getYAxisTitle = (primaryData, secondaryData, filters) => {
     unit = secondaryData[0].unit_name;
     variable = secondaryData[0].variable_name || filters.variable;
   }
-  
+
   // Format the variable and unit names
   const formattedVariable = formatVariableName(variable || filters.variable);
   const formattedUnit = formatUnitName(unit);
-  
+
   // Return formatted title
   if (formattedUnit) {
     return `${formattedVariable} (${formattedUnit})`;
   }
-  
+
   return formattedVariable;
 };

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -44,7 +44,7 @@ environments:
     variables:
       hostname: teehr.rtiamanzi.org
       certificateIssuerName: letsencrypt-prod
-      devTeehrVersion: 996fc1dc6c359590d3f2d0ebcb17a854b051246f
+      devTeehrVersion: 5963958df973e3859f656456c9e73a3a6c8a8022
       stableTeehrVersion: v0.6.5
       previousTeehrVersion: v0.5.3
       irsa:

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -23,7 +23,7 @@ environments:
     variables:
       hostname: teehr.local.app.garden
       certificateIssuerName: letsencrypt-prod
-      devTeehrVersion: 5963958df973e3859f656456c9e73a3a6c8a8022
+      devTeehrVersion: fc20673a371187241a57e39e542ae8aadbc80a13
       stableTeehrVersion: place-holder # Needed for sync to work for some reason.
       iceberg:
         inCluster: "true"
@@ -44,8 +44,8 @@ environments:
     variables:
       hostname: teehr.rtiamanzi.org
       certificateIssuerName: letsencrypt-prod
-      devTeehrVersion: 5963958df973e3859f656456c9e73a3a6c8a8022
-      stableTeehrVersion: v0.6.5
+      devTeehrVersion: fc20673a371187241a57e39e542ae8aadbc80a13
+      stableTeehrVersion: v0.6.6
       previousTeehrVersion: v0.5.3
       irsa:
         icebergReadOnlyRoleArn: arn:aws:iam::935462133478:role/teehr-hub-iceberg-s3-warehouse-readonly-irsa

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -23,7 +23,7 @@ environments:
     variables:
       hostname: teehr.local.app.garden
       certificateIssuerName: letsencrypt-prod
-      devTeehrVersion: 267f8a75034132aefe84749af10ab1562a6ac169
+      devTeehrVersion: 5963958df973e3859f656456c9e73a3a6c8a8022
       stableTeehrVersion: place-holder # Needed for sync to work for some reason.
       iceberg:
         inCluster: "true"


### PR DESCRIPTION
- Changes are limited to the forecast and retrospective dashboards. Allows users to filter primary (observations) by a specified timestep duration
- Includes a hardcoded mapping (dict) between displayed timestep duration and ISO duration (ex., {"Hourly (inst)": "PT1H"}) which includes hourly and 15min
- Updates the timeseries plot y-axis and legend labels
- Fixes the dashboard dropdown from being covered up by station search bar in map

Notes:
- Need to run the migrations in teehr-cloud-core to update the variable name in the teehr warehouse
- Also need to update TEEHR commit and redeploy so the USGS ingests don't continue to write data as `streamflow_hourly_inst` (ref: https://github.com/RTIInternational/teehr/pull/802)